### PR TITLE
Auto-refresh library after book add and update

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,7 +416,7 @@ with add_book_container:
                         st.session_state["last_added_id"] = (
                             book_data["isbn"] or book_data["title"]
                         )
-                        st.rerun()
+                        refresh_library()
                     except Exception as e:
                         st.error(f"Failed to add book: {e}")
             st.markdown("</div>", unsafe_allow_html=True)
@@ -622,7 +622,8 @@ for y in sorted(grouped.keys(), reverse=True):
                     
                                             st.success("Changes saved.")
                                             st.session_state[edit_key] = False
-                    
+                                            st.rerun()
+
                                         except Exception as e:
                                             st.error(f"Could not update Google Sheet: {e}")
                     
@@ -721,6 +722,7 @@ for y in sorted(grouped.keys(), reverse=True):
                                         st.success(
                                             "✅ Missing metadata filled and saved."
                                         )
+                                        st.rerun()
                                     except Exception as e:
                                         st.error(
                                             f"Could not update Google Sheet: {e}"


### PR DESCRIPTION
- After adding a book, call refresh_library() instead of bare st.rerun() so cache is cleared and the new book appears immediately in the list
- After saving book metadata edits, call st.rerun() to fully re-render the library with the updated values
- After enrichment metadata save, call st.rerun() for the same reason

https://claude.ai/code/session_01L1cgzujug5EkvcqNZgEWRD