### PR TITLE
Fix newly added book not appearing until page refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,6 +416,7 @@ with add_book_container:
                         st.session_state["last_added_id"] = (
                             book_data["isbn"] or book_data["title"]
                         )
+                        st.cache_data.clear()
                         st.rerun()
                     except Exception as e:
                         st.error(f"Failed to add book: {e}")


### PR DESCRIPTION
After adding a book, st.rerun() was called without clearing the st.cache_data cache first. This caused load_books() to return the stale cached list (missing the new book) on the next render cycle.

Adding st.cache_data.clear() before st.rerun() ensures the next render fetches fresh data from Google Sheets, so the new book appears immediately.

https://claude.ai/code/session_01X1pfgi7uMceAeZdS4F2qFC