### PR TITLE
Fix Claude enrichment 401 auth error and invalid API parameters

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,3 +1,3 @@
 
 [anthropic]
-api_key = "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"
+api_key = ""

--- a/enrichment.py
+++ b/enrichment.py
@@ -38,10 +38,10 @@ def enrich_book_metadata(title, author, isbn, existing=None):
     existing = existing or {}
 
     try:
-        # Get API key from Streamlit secrets, falling back to ANTHROPIC_API_KEY env var
+        # Get API key: env var takes priority over Streamlit secrets
         api_key = (
-            st.secrets.get("anthropic", {}).get("api_key")
-            or os.environ.get("ANTHROPIC_API_KEY")
+            os.environ.get("ANTHROPIC_API_KEY")
+            or st.secrets.get("anthropic", {}).get("api_key")
         )
 
         # Initialize the Anthropic client
@@ -73,9 +73,8 @@ Do not repeat existing values. Return ONLY the JSON object, no other text."""
 
         # Call Claude API
         response = client.messages.create(
-            model="claude-haiku-4-5",
+            model="claude-haiku-4-5-20251001",
             max_tokens=1024,
-            thinking={"type": "adaptive"},
             messages=[{"role": "user", "content": prompt}]
         )
 


### PR DESCRIPTION
- Clear invalid placeholder API key from secrets.toml; key must now come from the ANTHROPIC_API_KEY env var or a valid secrets.toml value
- Prioritise ANTHROPIC_API_KEY env var over Streamlit secrets so rotating keys doesn't require editing the secrets file
- Remove unsupported thinking={"type": "adaptive"} parameter (Haiku does not support extended thinking and "adaptive" is not a valid type)
- Use correct full model ID: claude-haiku-4-5-20251001

https://claude.ai/code/session_01JgduvuXc3jTBEnK5BaPMQy