### PR TITLE
Fix API auth error by not overriding system env vars with .env

### DIFF
--- a/enrichment.py
+++ b/enrichment.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-load_dotenv(override=True)
+load_dotenv()
 
 import os
 import json


### PR DESCRIPTION
load_dotenv(override=True) was replacing a valid ANTHROPIC_API_KEY already set in the environment with the value from .env, causing 401 authentication errors. Removing override=True lets the system environment variable take priority over .env.

https://claude.ai/code/session_01NLs34BDYmxy7iLgLA8xF9U